### PR TITLE
failing test case for datetime

### DIFF
--- a/DBD-Cassandra/t/30-types.t
+++ b/DBD-Cassandra/t/30-types.t
@@ -22,6 +22,7 @@ my $type_table= [
     ['int',         5,      $input],
     ['text',        '∫∫',   $input],
     ['timestamp',   time(), $input],
+    ['timestamp',   '2015-05-12T14:51:06.306+0000', $input],
     ['varchar',     '∫∫',   $input],
 ];
 


### PR DESCRIPTION
# Problem

I am trying to use a string like this as input for a datetime column.

'2015-05-12T14:51:06.306+0000'

http://cassandra.apache.org/doc/cql3/CQL.html#usingdates
# the test fails with this message

```
david@nbdt:~/dev/perl-DBD-Cassandra/DBD-Cassandra$ CASSANDRA_HOST=cassandra.cc.univie.ac.at prove -lvr t/30-types.t
t/30-types.t ..
1..17
ok 1
ok 2 - input match ascii
ok 3 - ascii raise error
ok 4 - input match bigint
ok 5
ok 6 - input match blob
ok 7 - input match boolean
ok 8 - input match boolean
ok 9 - perfect match boolean
ok 10 - perfect match boolean
ok 11 - input match double
ok 12 - perfect match float
ok 13 - input match int
ok 14 - input match text
ok 15 - input match timestamp
not ok 16 - input match timestamp

#   Failed test 'input match timestamp'
#   at t/30-types.t line 48.
#          got: '2015'
#     expected: '2015-05-12T14:51:06.306+0000'
ok 17 - input match varchar
# Looks like you failed 1 test of 17.
Dubious, test returned 1 (wstat 256, 0x100)
Failed 1/17 subtests 

Test Summary Report
-------------------
t/30-types.t (Wstat: 256 Tests: 17 Failed: 1)
  Failed test:  16
  Non-zero exit status: 1
Files=1, Tests=17,  0 wallclock secs ( 0.03 usr  0.00 sys +  0.10 cusr  0.02 csys =  0.15 CPU)
Result: FAIL
```
# and this is the column created in the DB (the row with id 6998)

cqlsh:dbd_cassandra_tests> select \* FROM dbd_cassandra_tests.test_type_timestamp  ;

 id   | test
------+--------------------------
 9145 | 2015-06-15 16:10:46+0200
 6998 | 1970-01-01 01:33:35+0100

(2 rows)
