### PR TITLE
add support for nested collections:

### DIFF
--- a/Cassandra-Client/t/03-types.t
+++ b/Cassandra-Client/t/03-types.t
@@ -178,6 +178,82 @@ check_simple([TYPE_SET, [ TYPE_INT ]], [
                                        ]);
 check_enc([TYPE_SET, [ TYPE_INT ]], [ 1, 2, 3 ], "\0\0\0\3\0\0\0\4\0\0\0\1\0\0\0\4\0\0\0\2\0\0\0\4\0\0\0\3");
 
+#nested list => map
+check_simple(
+    [TYPE_LIST,
+        [TYPE_MAP,
+            [TYPE_INT],[TYPE_BOOLEAN ]
+        ]
+    ],
+    [
+        [
+            { 1 => !1, 2 => !0},
+        ]
+    ],
+
+);
+check_enc(
+    [TYPE_LIST,
+        [TYPE_MAP,
+            [TYPE_INT],[TYPE_BOOLEAN ]
+        ]
+    ],
+    [
+        { 1 => !1, 2 => !0}
+    ],
+    pack("H*",'000000010000001e000000020000000400000001000000010000000004000000020000000101')
+);
+
+
+#nested set => map
+check_simple(
+    [TYPE_SET,
+        [TYPE_MAP,
+            [TYPE_INT],[TYPE_BOOLEAN ]
+        ]
+    ],
+    [
+        [
+            { 1 => !1, 2 => !0},
+        ]
+    ],
+
+);
+check_enc(
+    [TYPE_SET,
+        [TYPE_MAP,
+            [TYPE_INT],[TYPE_BOOLEAN ]
+        ]
+    ],
+    [
+        { 1 => !1, 2 => !0}
+    ],
+    pack("H*",'000000010000001e000000020000000400000001000000010000000004000000020000000101')
+);
+
+
+#nested map => list
+check_simple(
+    [TYPE_MAP,
+        [TYPE_INT],[TYPE_LIST, [TYPE_INT] ]
+    ],
+    [
+
+        { 1 => [2], 2 => [3]},
+
+    ],
+
+);
+check_enc(
+
+    [TYPE_MAP,
+        [TYPE_INT],[TYPE_LIST, [TYPE_INT]]
+    ],
+    { 1 => [2], 2 => [3]}
+    ,
+    pack("H*",'0000000200000004000000010000000c00000001000000040000000200000004000000020000000c000000010000000400000003')
+);
+
 # UDT
 
 # Tuple


### PR DESCRIPTION
Nested collections were not supported because when generating the code, $tmp_output was
used which would get clobbered by the inner collection.

In order to support nested collections a level variable was added to to the $tmp_output name
that is incremented for every inner loop, this supports multiple levels of nesting
