### PR TITLE
fix multiple async response

### DIFF
--- a/Cassandra-Client/Changes
+++ b/Cassandra-Client/Changes
@@ -1,5 +1,10 @@
 Revision history for Cassandra-Client
 
+0.19    unreleased
+
+      * Fix bug with multiple async requests returning result for other
+        requests
+
 0.18    2020/11/12
 
       * Improve SASL interface

--- a/Cassandra-Client/t/40-multiple-async-queries-response.t
+++ b/Cassandra-Client/t/40-multiple-async-queries-response.t
@@ -1,0 +1,51 @@
+#!perl
+use 5.010;
+use strict;
+use warnings;
+use File::Basename qw//; use lib File::Basename::dirname(__FILE__).'/lib';
+use Test::More;
+use TestCassandra;
+use Cassandra::Client::Policy::Throttle::Adaptive;
+use Time::HiRes qw/time/;
+use AnyEvent::XSPromises qw/collect/;
+use AnyEvent;
+
+my $nr_rows = $ENV{PARALLEL_TEST_RECORDS} || 10;
+plan skip_all => "Missing Cassandra test environment" unless TestCassandra->is_ok;
+plan tests => $nr_rows;
+
+my $client= TestCassandra->new(
+    anyevent  => 1,
+);
+$client->connect();
+
+my $db= 'perl_cassandra_client_tests';
+$client->execute("drop keyspace if exists $db");
+$client->execute("create keyspace $db with replication={'class':'SimpleStrategy', 'replication_factor': 1}");
+$client->execute("create table $db.test_int (id int primary key, value int)");
+
+for (1..$nr_rows) {
+    $client->execute("insert into $db.test_int (id, value) values (?, ?)", [$_, $_]);
+}
+
+my $insert_query= "insert into $db.test_int (id, value) values (?, ?)";
+my $select_query= "select id, value from $db.test_int where id=?";
+
+my @promises;
+for (1..$nr_rows) {
+    my $requested_id = $_;
+    push @promises, $client->async_execute($select_query, [ $requested_id ])
+        ->then(sub {
+            my $rs = shift;
+            my $rs_id = @{$rs->row_hashes()}[0]->{"id"};
+            ok($rs_id == $requested_id, "response matches request for id <$requested_id>");
+            return undef;
+        });
+}
+
+my $cv= AE::cv;
+my $fail;
+collect(@promises)->then(sub { $cv->send; }, sub { $fail= 1; $cv->send; });
+$cv->recv;
+
+1;


### PR DESCRIPTION
Fix an issue where responses for an async query gets overwritten by another's.

E.g. this can warn:

```perl
my $select_query= "select id, value from $db.test_int where id=?";
my @promises;
for (1..10) {
    my $requested_id = $_;
    push @promises, $client->async_execute($select_query, [ $requested_id ])
        ->then(sub {
                my $rs = shift;
                my $rs_id = @{$rs->row_hashes()}[0]->{"id"};
               warn "expected <$requested_id> but got <$rs_id>" if $requested_id != $rs_id;
               return;
        });
}
collect(@promises);
```

I reported the issue internally, but I didn't investigate the issue myself. Any errors with the report are my own.

Analysis from other perl hackers point to using `goto` in `Cassandra::Client::Connection::can_read`,
causing the `$body` variable to become dynamically scoped. Which meant it could be overwritten before the `$cb` had time to process it.

Besides the current fix, other possible fixes are:
1. Moving the $body parsing to a different method (creates a new lexical scope for `my (...,$body)=@_`);
2. Creating a copy of $body before calling the $cb (the `$body_copy` would be on a new lexical scope).

This fix was chosen as I don't know if other users of `$body` could also have deferred execution (so doing a copy only with calling `$cb` might not be enough); or if there would be performance concerns with 1.