### PR TITLE
Use query to set keyspace instead of prepared statements

### DIFF
--- a/Cassandra-Client/Changes
+++ b/Cassandra-Client/Changes
@@ -1,5 +1,10 @@
 Revision history for Cassandra-Client
 
+0.20    2022/06/20
+
+      * Use query to set keyspace instead of prepared statements
+
+
 0.19    2022/03/03
 
       * Fix bug with multiple async requests returning result for other

--- a/Cassandra-Client/lib/Cassandra/Client/Connection.pm
+++ b/Cassandra-Client/lib/Cassandra/Client/Connection.pm
@@ -559,7 +559,8 @@ sub handshake {
         sub {
             my ($next)= @_;
             if ($self->{options}{keyspace}) {
-                return $self->execute_prepared($next, \('use "'.$self->{options}{keyspace}.'"'));
+                my $query = 'use "'.$self->{options}{keyspace}.'"';
+                return $self->request($next, OPCODE_QUERY, pack_longstring($query).pack_queryparameters(1, 0, 0, 0, undef, undef));
             }
             return $next->();
         },


### PR DESCRIPTION
## Issue

Using prepared statement to set keyspace is deprecated. Ref: CASSANDRA-17248

[CASSANDRA-17248](https://issues.apache.org/jira/browse/CASSANDRA-17248) introduced a warning in Cassandra 4.0.3 when using `use keyspace`. And the perl driver uses a prepared statement to select the keyspace when creating a connection. Due to this, we get a lot of warnings on the client everytime a connection is created. 

The warning looks something like this
```
`USE <keyspace>` with prepared statements is considered to be an anti-pattern due to ambiguity in non-qualified table names. Please consider removing instances of `Session#setKeyspace(<keyspace>)`, `Session#execute("USE <keyspace>")` and `cluster.newSession(<keyspace>)` from your code, and always use fully qualified table names (e.g. <keyspace>.<table>). Keyspace used: null, statement keyspace: null, statement id: <id> at Cassandra/Client/Connection.pm line 957.
```
[source](https://github.com/apache/cassandra/commit/242f7f9b18db77bce36c9bba00b2acda4ff3209e#diff-050b0e261bb49fb355ab71b5fd066b79dd6c5600ffecb91ffb2d4dabca76a87b)

Another relevant issue why this was deprecated - [CASSANDRA-15252](https://issues.apache.org/jira/browse/CASSANDRA-15252)

## Fix

The PR changes it to use query. The java driver by datastax also uses query to set the keyspace.
The following screenshot is from a tcpdump of connection initiated by java driver
![image](https://user-images.githubusercontent.com/6232245/174638868-9f191ffa-661f-4452-ad45-dd59a3137b6c.png)

After current PR, in perl driver

![image](https://user-images.githubusercontent.com/6232245/174639164-a006bc50-e0ff-4cc1-bc57-c339d4956420.png)

Between the 2 screenshots, there is a change in consistency. But it does not matter for `use keyspace` https://cassandra.apache.org/_/native_protocol.html

